### PR TITLE
chore(deps): lock typescript version to 4.7.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "textlint-rule-terminology": "^2.1.6",
         "ts-jest": "^28.0.8",
         "ts-node": "^10.8.1",
-        "typescript": "^4.7.4",
+        "typescript": "~4.7.4",
         "webpack": "^5.73.0",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "textlint-rule-terminology": "^2.1.6",
     "ts-jest": "^28.0.8",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.4",
+    "typescript": "~4.7.4",
     "webpack": "^5.73.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.10.0",


### PR DESCRIPTION
@typescript-eslint 5.27 doesn't support typescript > v4.7