### PR TITLE
Added Splash component and global styles

### DIFF
--- a/src/view/components/index.scss
+++ b/src/view/components/index.scss
@@ -26,4 +26,21 @@ body {
     width: 100%;
     height: 100%;
   }
+
+  .splash {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #f5f5f5;
+  }
+  
+  .splash-content {
+    text-align: center;
+  }
+  
 }

--- a/src/view/components/index.tsx
+++ b/src/view/components/index.tsx
@@ -1,10 +1,12 @@
 import Toolbar from './toolbar';
+import Splash from './splash';
 
 import './index.scss';
 
 export default function App(): JSX.Element {
   return (
     <>
+      <Splash />
       <Toolbar />
       <div id="workspace"></div>
     </>
@@ -22,3 +24,7 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById('root'),
 );
+
+// -------------------------------------------------------------------------------------------------
+
+

--- a/src/view/components/splash.tsx
+++ b/src/view/components/splash.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Splash: React.FC = () => {
+  return (
+    <div className="splash">
+      <div className="splash-content">
+        <h1>Welcome to Music Blocks (v4)</h1>
+        <p>This is a temporary splash screen.</p>
+      </div>
+    </div>
+  );
+};
+
+export default Splash;


### PR DESCRIPTION
#221 

## Changes Made
- Added a Splash component to the root of the app
- Added global styles for the splash screen and other elements

## Reasoning
I added the Splash component as a temporary splash screen for the app. The global styles were added to improve the layout and appearance of the app.

## Testing
I tested the app on different screen sizes to ensure that the splash screen and other elements were displayed correctly.

## Completed
- Added Splash component
- Added global styles

## Pending
- Add more detailed design to the splash screen
- Add a loading spinner to the splash screen

## Screenshot

![Screenshot (115)](https://user-images.githubusercontent.com/96035378/210223046-952c36fc-e595-435f-b679-c165f25339c2.png)
