### PR TITLE
[fix]: env_file removed from docker-compose musicblocksv4

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@sugarlabs:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=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

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
   musicblocks:
     build: ./
     image: ghcr.io/sugarlabs/musicblocks:4-dev
-    env_file:
-      - ./env/development.env
     ports:
       - '5173:5173' # development server
       - '4173:4173' # production preview server


### PR DESCRIPTION
The env folder is bind mounted with the rest anyway
env_file is used to add env variables directly in the shell.This app is doesn't using env_file.