### PR TITLE
fix(stats): fix assets stats collection

### DIFF
--- a/tools/scripts/stats.ts
+++ b/tools/scripts/stats.ts
@@ -138,7 +138,7 @@ export function getStats(data: VisualizerData): {
             .readdirSync(path.resolve(root, 'dist', 'assets'), { withFileTypes: true })
             .filter((dirent) => dirent.isFile())
             .map((dirent) => dirent.name)
-            .filter((name) => /\.(png|jpg|jpeg|gif|svg)$/.test(name));
+            .filter((name) => /\.(png|jpg|jpeg|gif|svg|mp3|ogg|wav|xml)$/.test(name));
 
         const assetsStats: Record<string, number> = {};
 

--- a/tools/scripts/stats.ts
+++ b/tools/scripts/stats.ts
@@ -132,9 +132,24 @@ export function getStats(data: VisualizerData): {
     };
 
     const _getSizeAssets = (): Record<string, number> => {
-        return Object.fromEntries(
-            _getSizeFiles('/src/assets/').filter(([file]) => !file.endsWith('.ts')),
-        );
+        const root = process.cwd();
+
+        const assetsFiles = fs
+            .readdirSync(path.resolve(root, 'dist', 'assets'), { withFileTypes: true })
+            .filter((dirent) => dirent.isFile())
+            .map((dirent) => dirent.name)
+            .filter((name) => /\.(png|jpg|jpeg|gif|svg)$/.test(name));
+
+        const assetsStats: Record<string, number> = {};
+
+        assetsFiles.forEach((file) => {
+            // Get the size of the file in bytes
+            const size = fs.statSync(path.resolve(root, 'dist', 'assets', file)).size;
+
+            assetsStats[file] = size;
+        });
+
+        return assetsStats;
     };
 
     return {


### PR DESCRIPTION
Fixes for the problems discussed in issue #317 

fixes #317 

- Used native `fs` module to get all the asset files (`png, jpg, jpeg, gif, svg, mp3, ogg, wav, xml` for now) and their sizes, then write the `dist/stats.json` file with the complete hashed path of the assets with their sizes in bytes.

Below is the generated `dist/stats.json` file.

```json
{
  "i18n": { "en": 104, "es": 120 },
  "assets": {
    "build-53e87ed8.svg": 2740,
    "close-444dc9a6.svg": 1412,
    "code-74870b2e.svg": 1808,
    "exportDrawing-aee43b5d.svg": 700,
    "help-a0383ce2.svg": 1329,
    "logo-3080f493.png": 46593,
    "mouse-46cf41ce.svg": 3125,
    "pin-8515e01d.svg": 1704,
    "reset-a8de2102.svg": 1555,
    "run-123f2282.svg": 1328,
    "saveProjectHTML-f9e0b620.svg": 2870,
    "startRecording-5dec9e0d.svg": 1643,
    "stop-aa193098.svg": 1162,
    "stopRecording-48f9a011.svg": 905,
    "unpin-427cfcc6.svg": 1746
  },
  "modules": { "menu": 1394, "editor": 35200, "singer": 226021, "painter": 219016 }
}
```

This will also help to fix the loading percentage issue related to #288 