### PR TITLE
feat(splash): sync splash progress with the sizes of items

### DIFF
--- a/src/@types/app.d.ts
+++ b/src/@types/app.d.ts
@@ -39,7 +39,7 @@ export interface IAppConfig {
 
 /** Type definition for the map of items imported at app load. */
 export type TAppImportMap = {
-    lang: TI18nLang | undefined;
+    lang: Partial<Record<TI18nLang, boolean>>;
     assets: Record<string, boolean>;
     components: Partial<Record<TComponentId, boolean>>;
 };

--- a/src/@types/env.d.ts
+++ b/src/@types/env.d.ts
@@ -9,13 +9,3 @@ declare module '*.svg' {
 declare module '*.jsonc';
 
 declare module '*.wasm';
-
-declare module 'virtual:stats' {
-    const stats:
-        | {
-              i18n: Record<string, number>;
-              assets: Record<string, number>;
-              modules: Record<string, number>;
-          }
-        | undefined;
-}

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -11,7 +11,7 @@ import type { TI18nLang } from '@/@types/core/i18n';
 // -------------------------------------------------------------------------------------------------
 
 const _importMap: TAppImportMap = {
-    lang: undefined,
+    lang: {},
     assets: {},
     components: {},
 };
@@ -27,7 +27,7 @@ function _updateImportMap(item: 'assets', subitem: string): TAppImportMap;
 function _updateImportMap(item: 'components', subitem: TComponentId): TAppImportMap;
 function _updateImportMap(item: keyof TAppImportMap, subitem?: string): TAppImportMap {
     if (item === 'lang') {
-        _importMap.lang = subitem as TI18nLang;
+        _importMap.lang[subitem as TI18nLang] = true;
     } else if (item === 'assets') {
         const assets = { ..._importMap.assets };
         assets[subitem as string] = true;
@@ -121,8 +121,9 @@ async function init(config?: IAppConfig) {
                 const allComponentsSize = getComponentsSize();
                 const loadedComponentsSize = getComponentsSize(false);
 
-                const allLangSize = stats.i18n.en as number;
-                const loadedLangSize = data.lang ? (stats.i18n.en as number) : 0;
+                const langName = Object.keys(data.lang)[0] as TI18nLang;
+                const allLangSize = stats.i18n[langName];
+                const loadedLangSize = data.lang[langName] ? allLangSize : 0;
 
                 const totalSize = allAssetsSize + allComponentsSize + allLangSize;
                 const loadedSize = loadedAssetsSize + loadedComponentsSize + loadedLangSize;
@@ -164,6 +165,7 @@ async function init(config?: IAppConfig) {
             }
         })();
 
+        _importMap.lang = Object.fromEntries([[importItemLang, false]]);
         _importMap.assets = Object.fromEntries(importListAssets.map((assetId) => [assetId, false]));
         _importMap.components = Object.fromEntries(
             importListComponents.map((componentId) => [componentId, false]),

--- a/tools/vite.config.ts
+++ b/tools/vite.config.ts
@@ -63,35 +63,6 @@ export default defineConfig({
             gzipSize: true,
             template: 'raw-data',
         }),
-
-        // only for use in DEV mode
-        {
-            name: 'stats-plugin',
-            resolveId(id) {
-                if (id === 'virtual:stats') {
-                    return '\0' + 'virtual:stats';
-                }
-            },
-            load(id) {
-                if (id === '\0' + 'virtual:stats') {
-                    let stats:
-                        | {
-                              i18n: Record<string, number>;
-                              assets: Record<string, number>;
-                              modules: Record<string, number>;
-                          }
-                        | undefined;
-                    try {
-                        // if build was run before, this will be present
-                        // eslint-disable-next-line
-                        stats = require('../dist/stats.json');
-                    } catch (e) {
-                        // do nothing
-                    }
-                    return `export const stats = ${JSON.stringify(stats)}`;
-                }
-            },
-        },
     ],
 
     resolve: {


### PR DESCRIPTION


Syncing and updating the splash progress with the stats data using item sizes instead of item counts.

This PR will introduce the following changes:
- Update the splash screen progress with 
```diff
- (loaded items count / total items to be loaded count)
+ (loaded items size / total items to be loaded size)
```

To test and make sure that the code is working, PR #318 needs to be merged first.