### PR TITLE
fix(view): overlay view overflow

### DIFF
--- a/src/core/view/components/index.scss
+++ b/src/core/view/components/index.scss
@@ -14,12 +14,12 @@
     z-index: 9999;
     top: 0;
     width: 100%;
-    height: 200%;
+    height: 100%;
 
     #root-overlay-body {
       position: relative;
       width: 100%;
-      height: 50%;
+      height: 100%;
     }
   }
 


### PR DESCRIPTION
The overlay overflows due to 200% height.

![image](https://user-images.githubusercontent.com/33328728/221397774-35ee39b9-b8a4-459a-97ef-e45a0eee33c2.png)