### PR TITLE
feat(singer): add playground app

### DIFF
--- a/modules/singer/package.json
+++ b/modules/singer/package.json
@@ -5,6 +5,7 @@
   "private": "true",
   "main": "src/index.ts",
   "scripts": {
+    "playground": "vite playground --host --port 5601",
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "check": "tsc",

--- a/modules/singer/playground/index.html
+++ b/modules/singer/playground/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Playground — Singer</title>
+
+    <style>
+      html,
+      body {
+        width: 100vw;
+        height: 100vh;
+        margin: 0;
+        padding: 0;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+          'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      * {
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="playground-root"></div>
+    <script type="module" src="index.tsx"></script>
+  </body>
+</html>

--- a/modules/singer/playground/index.tsx
+++ b/modules/singer/playground/index.tsx
@@ -1,0 +1,18 @@
+import { createRoot } from 'react-dom/client';
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
+
+import PageVoice from './pages/Voice';
+
+const router = createBrowserRouter([
+  {
+    path: 'voice',
+    element: <PageVoice />,
+  },
+  {
+    path: '/',
+    element: <Navigate to="voice" />,
+  },
+]);
+
+const root = createRoot(document.getElementById('playground-root') as HTMLElement);
+root.render(<RouterProvider router={router} />);

--- a/modules/singer/playground/pages/Voice.tsx
+++ b/modules/singer/playground/pages/Voice.tsx
@@ -1,0 +1,3 @@
+export default function (): JSX.Element {
+  return <div>Voice Testbench</div>;
+}

--- a/modules/singer/playground/vite.config.ts
+++ b/modules/singer/playground/vite.config.ts
@@ -1,0 +1,18 @@
+import path from 'path';
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [
+        //
+        react(),
+    ],
+
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, '..', 'src'),
+        },
+        extensions: ['.tsx', '.ts', '.js', '.scss', '.sass', '.json'],
+    },
+});


### PR DESCRIPTION
Adds a React/Vite app inside the `singer` module. This is to be used for testing things that are to be run on the browser.

To start, run `npm run playground` inside `modules/singer`