### PR TITLE
Implement `extent` and `coords` for the args and notches

### DIFF
--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -116,8 +116,8 @@ export interface IBrick extends IBrickStyle {
     // states
     /** whether brick is highlighted */
     highlighted: boolean;
-    /** bounding box dimensions of the brick */
-    get extent(): TBrickExtent;
+    /** Bounding box dimensions and coords of the brick */
+    get bBoxBrick(): { extent: TBrickExtent; coords: TBrickCoords };
 
     /** SVG string for the brick based on defining properties and current state */
     get SVGpaths(): string[];

--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -125,6 +125,20 @@ export interface IBrickNotchInsTopState {
 
 /**
  * @interface
+ * State properties associated with bricks that have bottom instruction notch.
+ */
+export interface IBrickNotchInsBotState {
+    /** Bounding box dimensions and coords of the bottom instruction notch */
+    get bBoxNotchInsBot(): {
+        /** Bounding box dimensions of the bottom instruction notch */
+        extent: TBrickExtent;
+        /** Co-ordinates of the bottom instruction notch relative to the brick */
+        coords: TBrickCoords;
+    };
+}
+
+/**
+ * @interface
  * Type definition of a generic brick (any type).
  */
 export interface IBrick extends IBrickStyle {
@@ -203,7 +217,10 @@ export interface IBrickExpression
  * Type definition of a statement brick.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IBrickStatement extends IBrickInstruction, IBrickNotchInsTopState {
+export interface IBrickStatement
+    extends IBrickInstruction,
+        IBrickNotchInsTopState,
+        IBrickNotchInsBotState {
     // reserving spot for future-proofing
 }
 
@@ -211,7 +228,11 @@ export interface IBrickStatement extends IBrickInstruction, IBrickNotchInsTopSta
  * @interface
  * Type definition of a block brick.
  */
-export interface IBrickBlock extends IBrickInstruction, IBrickNotchState, IBrickNotchInsTopState {
+export interface IBrickBlock
+    extends IBrickInstruction,
+        IBrickNotchState,
+        IBrickNotchInsTopState,
+        IBrickNotchInsBotState {
     // state
     /** combined bounding box of the instructions nested within the brick */
     get nestExtent(): TBrickExtent;

--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -97,14 +97,28 @@ export interface IBrickArgsState {
 
 /**
  * @interface
- * State properties associated with bricks that have notch.
+ * State properties associated with bricks that have left notch.
  */
 export interface IBrickNotchState {
-    /** Map of argument ID to corresponding extent and coords */
+    /** Bounding box dimensions and coords of the left notch */
     get bBoxNotchArg(): {
-        /** Bounding box dimensions of the notch */
+        /** Bounding box dimensions of the left notch */
         extent: TBrickExtent;
-        /** Co-ordinates of the notch relative to the brick */
+        /** Co-ordinates of the left notch relative to the brick */
+        coords: TBrickCoords;
+    };
+}
+
+/**
+ * @interface
+ * State properties associated with bricks that have top instruction notch.
+ */
+export interface IBrickNotchInsTopState {
+    /** Bounding box dimensions and coords of the top instruction notch */
+    get bBoxNotchInsTop(): {
+        /** Bounding box dimensions of the top instruction notch */
+        extent: TBrickExtent;
+        /** Co-ordinates of the top instruction notch relative to the brick */
         coords: TBrickCoords;
     };
 }
@@ -189,7 +203,7 @@ export interface IBrickExpression
  * Type definition of a statement brick.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IBrickStatement extends IBrickInstruction {
+export interface IBrickStatement extends IBrickInstruction, IBrickNotchInsTopState {
     // reserving spot for future-proofing
 }
 
@@ -197,7 +211,7 @@ export interface IBrickStatement extends IBrickInstruction {
  * @interface
  * Type definition of a block brick.
  */
-export interface IBrickBlock extends IBrickInstruction, IBrickNotchState {
+export interface IBrickBlock extends IBrickInstruction, IBrickNotchState, IBrickNotchInsTopState {
     // state
     /** combined bounding box of the instructions nested within the brick */
     get nestExtent(): TBrickExtent;

--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -139,6 +139,20 @@ export interface IBrickNotchInsBotState {
 
 /**
  * @interface
+ * State properties associated with bricks that have nesting.
+ */
+export interface IBrickNotchInsNestTopState {
+    /** Bounding box dimensions and coords of the top instruction notch of the nesting */
+    get bBoxNotchInsNestTop(): {
+        /** Bounding box dimensions of the top instruction notch of the nesting */
+        extent: TBrickExtent;
+        /** Co-ordinates of the top instruction notch of the nesting relative to the brick */
+        coords: TBrickCoords;
+    };
+}
+
+/**
+ * @interface
  * Type definition of a generic brick (any type).
  */
 export interface IBrick extends IBrickStyle {
@@ -232,7 +246,8 @@ export interface IBrickBlock
     extends IBrickInstruction,
         IBrickNotchState,
         IBrickNotchInsTopState,
-        IBrickNotchInsBotState {
+        IBrickNotchInsBotState,
+        IBrickNotchInsNestTopState {
     // state
     /** combined bounding box of the instructions nested within the brick */
     get nestExtent(): TBrickExtent;

--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -84,9 +84,9 @@ export interface IBrickArgs {
  */
 export interface IBrickArgsState {
     /** map of argument ID to corresponding bounding box dimensions */
-    get argsExtent(): Record<string, IBrickExtent>;
+    get argsExtent(): Record<string, TBrickExtent>;
     /** map of argument ID to co-ordinates of the argument connections relative to the brick */
-    get argsCoords(): Record<string, IBrickCoords>;
+    get argsCoords(): Record<string, TBrickCoords>;
 }
 
 /**
@@ -111,7 +111,7 @@ export interface IBrick extends IBrickStyle {
     /** whether brick is highlighted */
     highlighted: boolean;
     /** bounding box dimensions of the brick */
-    get extent(): IBrickExtent;
+    get extent(): TBrickExtent;
 
     /** SVG string for the brick based on defining properties and current state */
     get SVGpaths(): string[];
@@ -176,7 +176,7 @@ export interface IBrickStatement extends IBrickInstruction {
 export interface IBrickBlock extends IBrickInstruction {
     // state
     /** combined bounding box of the instructions nested within the brick */
-    get nestExtent(): IBrickExtent;
+    get nestExtent(): TBrickExtent;
     /** whether brick nesting is hidden */
     collapsed: boolean;
 }

--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -83,10 +83,13 @@ export interface IBrickArgs {
  * State properties associated with bricks that can take arguments.
  */
 export interface IBrickArgsState {
-    /** map of argument ID to corresponding bounding box dimensions */
-    get argsExtent(): Record<string, TBrickExtent>;
-    /** map of argument ID to co-ordinates of the argument connections relative to the brick */
-    get argsCoords(): Record<string, TBrickCoords>;
+    /** map of argument ID to to corresponding extent and coords */
+    get bBoxArgs(): {
+        /** map of argument ID to corresponding bounding box dimensions */
+        extent: Record<string, TBrickExtent>;
+        /** map of argument ID to co-ordinates of the argument connections relative to the brick */
+        coords: Record<string, TBrickCoords>;
+    };
 }
 
 /**

--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -83,13 +83,16 @@ export interface IBrickArgs {
  * State properties associated with bricks that can take arguments.
  */
 export interface IBrickArgsState {
-    /** map of argument ID to to corresponding extent and coords */
-    get bBoxArgs(): {
-        /** map of argument ID to corresponding bounding box dimensions */
-        extent: Record<string, TBrickExtent>;
-        /** map of argument ID to co-ordinates of the argument connections relative to the brick */
-        coords: Record<string, TBrickCoords>;
-    };
+    /** Map of argument ID to corresponding extent and coords */
+    get bBoxArgs(): Record<
+        string,
+        {
+            /** Bounding box dimensions */
+            extent: TBrickExtent;
+            /** Co-ordinates of the argument connections relative to the brick */
+            coords: TBrickCoords;
+        }
+    >;
 }
 
 /**

--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -97,62 +97,6 @@ export interface IBrickArgsState {
 
 /**
  * @interface
- * State properties associated with bricks that have left notch.
- */
-export interface IBrickNotchState {
-    /** Bounding box dimensions and coords of the left notch */
-    get bBoxNotchArg(): {
-        /** Bounding box dimensions of the left notch */
-        extent: TBrickExtent;
-        /** Co-ordinates of the left notch relative to the brick */
-        coords: TBrickCoords;
-    };
-}
-
-/**
- * @interface
- * State properties associated with bricks that have top instruction notch.
- */
-export interface IBrickNotchInsTopState {
-    /** Bounding box dimensions and coords of the top instruction notch */
-    get bBoxNotchInsTop(): {
-        /** Bounding box dimensions of the top instruction notch */
-        extent: TBrickExtent;
-        /** Co-ordinates of the top instruction notch relative to the brick */
-        coords: TBrickCoords;
-    };
-}
-
-/**
- * @interface
- * State properties associated with bricks that have bottom instruction notch.
- */
-export interface IBrickNotchInsBotState {
-    /** Bounding box dimensions and coords of the bottom instruction notch */
-    get bBoxNotchInsBot(): {
-        /** Bounding box dimensions of the bottom instruction notch */
-        extent: TBrickExtent;
-        /** Co-ordinates of the bottom instruction notch relative to the brick */
-        coords: TBrickCoords;
-    };
-}
-
-/**
- * @interface
- * State properties associated with bricks that have nesting.
- */
-export interface IBrickNotchInsNestTopState {
-    /** Bounding box dimensions and coords of the top instruction notch of the nesting */
-    get bBoxNotchInsNestTop(): {
-        /** Bounding box dimensions of the top instruction notch of the nesting */
-        extent: TBrickExtent;
-        /** Co-ordinates of the top instruction notch of the nesting relative to the brick */
-        coords: TBrickCoords;
-    };
-}
-
-/**
- * @interface
  * Type definition of a generic brick (any type).
  */
 export interface IBrick extends IBrickStyle {
@@ -186,6 +130,14 @@ export interface IBrick extends IBrickStyle {
 export interface IBrickArgument extends IBrick {
     /** data type returned by an argument brick */
     get dataType(): TBrickArgDataType;
+
+    /** Bounding box dimensions and coords of the left notch */
+    get bBoxNotchArg(): {
+        /** Bounding box dimensions of the left notch */
+        extent: TBrickExtent;
+        /** Co-ordinates of the left notch relative to the brick */
+        coords: TBrickCoords;
+    };
 }
 
 /**
@@ -198,13 +150,29 @@ export interface IBrickInstruction extends IBrick, IBrickArgs, IBrickArgsState {
     get connectAbove(): boolean;
     /** is connection allowed below the brick */
     get connectBelow(): boolean;
+
+    /** Bounding box dimensions and coords of the top instruction notch */
+    get bBoxNotchInsTop(): {
+        /** Bounding box dimensions of the top instruction notch */
+        extent: TBrickExtent;
+        /** Co-ordinates of the top instruction notch relative to the brick */
+        coords: TBrickCoords;
+    };
+
+    /** Bounding box dimensions and coords of the bottom instruction notch */
+    get bBoxNotchInsBot(): {
+        /** Bounding box dimensions of the bottom instruction notch */
+        extent: TBrickExtent;
+        /** Co-ordinates of the bottom instruction notch relative to the brick */
+        coords: TBrickCoords;
+    };
 }
 
 /**
  * @interface
  * Type definition of a data brick.
  */
-export interface IBrickData extends IBrickArgument, IBrickNotchState {
+export interface IBrickData extends IBrickArgument {
     /** whether brick has a static label or value can be updated */
     get dynamic(): boolean;
     /** (if dynamic) current value of the brick */
@@ -218,11 +186,7 @@ export interface IBrickData extends IBrickArgument, IBrickNotchState {
  * Type definition of an argument brick.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IBrickExpression
-    extends IBrickArgument,
-        IBrickArgs,
-        IBrickArgsState,
-        IBrickNotchState {
+export interface IBrickExpression extends IBrickArgument, IBrickArgs, IBrickArgsState {
     // reserving spot for future-proofing
 }
 
@@ -231,10 +195,7 @@ export interface IBrickExpression
  * Type definition of a statement brick.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IBrickStatement
-    extends IBrickInstruction,
-        IBrickNotchInsTopState,
-        IBrickNotchInsBotState {
+export interface IBrickStatement extends IBrickInstruction {
     // reserving spot for future-proofing
 }
 
@@ -242,15 +203,18 @@ export interface IBrickStatement
  * @interface
  * Type definition of a block brick.
  */
-export interface IBrickBlock
-    extends IBrickInstruction,
-        IBrickNotchState,
-        IBrickNotchInsTopState,
-        IBrickNotchInsBotState,
-        IBrickNotchInsNestTopState {
+export interface IBrickBlock extends IBrickInstruction, IBrickNotchInsNestTopState {
     // state
     /** combined bounding box of the instructions nested within the brick */
     get nestExtent(): TBrickExtent;
     /** whether brick nesting is hidden */
     collapsed: boolean;
+
+    /** Bounding box dimensions and coords of the top instruction notch of the nesting */
+    get bBoxNotchInsNestTop(): {
+        /** Bounding box dimensions of the top instruction notch of the nesting */
+        extent: TBrickExtent;
+        /** Co-ordinates of the top instruction notch of the nesting relative to the brick */
+        coords: TBrickCoords;
+    };
 }

--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -120,7 +120,7 @@ export interface IBrick extends IBrickStyle {
     get bBoxBrick(): { extent: TBrickExtent; coords: TBrickCoords };
 
     /** SVG string for the brick based on defining properties and current state */
-    get SVGpaths(): string[];
+    get SVGpath(): string;
 }
 
 /**

--- a/modules/code-builder/src/@types/brick.d.ts
+++ b/modules/code-builder/src/@types/brick.d.ts
@@ -97,6 +97,20 @@ export interface IBrickArgsState {
 
 /**
  * @interface
+ * State properties associated with bricks that have notch.
+ */
+export interface IBrickNotchState {
+    /** Map of argument ID to corresponding extent and coords */
+    get bBoxNotchArg(): {
+        /** Bounding box dimensions of the notch */
+        extent: TBrickExtent;
+        /** Co-ordinates of the notch relative to the brick */
+        coords: TBrickCoords;
+    };
+}
+
+/**
+ * @interface
  * Type definition of a generic brick (any type).
  */
 export interface IBrick extends IBrickStyle {
@@ -148,7 +162,7 @@ export interface IBrickInstruction extends IBrick, IBrickArgs, IBrickArgsState {
  * @interface
  * Type definition of a data brick.
  */
-export interface IBrickData extends IBrickArgument {
+export interface IBrickData extends IBrickArgument, IBrickNotchState {
     /** whether brick has a static label or value can be updated */
     get dynamic(): boolean;
     /** (if dynamic) current value of the brick */
@@ -162,7 +176,11 @@ export interface IBrickData extends IBrickArgument {
  * Type definition of an argument brick.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IBrickExpression extends IBrickArgument, IBrickArgs, IBrickArgsState {
+export interface IBrickExpression
+    extends IBrickArgument,
+        IBrickArgs,
+        IBrickArgsState,
+        IBrickNotchState {
     // reserving spot for future-proofing
 }
 
@@ -179,7 +197,7 @@ export interface IBrickStatement extends IBrickInstruction {
  * @interface
  * Type definition of a block brick.
  */
-export interface IBrickBlock extends IBrickInstruction {
+export interface IBrickBlock extends IBrickInstruction, IBrickNotchState {
     // state
     /** combined bounding box of the instructions nested within the brick */
     get nestExtent(): TBrickExtent;

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -67,12 +67,7 @@ export default class BrickBlock extends BrickModelBlock {
         return result;
     }
 
-    public get SVGpaths(): string[] {
-        let result: string[] = [];
-
-        const path = this._pathResults.path;
-        result.push(path);
-
-        return result;
+    public get SVGpath(): string {
+        return this._pathResults.path;
     }
 }

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -48,7 +48,6 @@ export default class BrickBlock extends BrickModelBlock {
 
         const path = generatePath({
             hasNest: true,
-            hasNotchNest: true,
             hasNotchArg: true,
             hasNotchInsTop: this._connectAbove,
             hasNotchInsBot: this._connectBelow,

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -10,6 +10,8 @@ import { generatePath } from './utils/path';
  * Final class that defines a block brick.
  */
 export default class BrickBlock extends BrickModelBlock {
+    readonly _pathResults: ReturnType<typeof generatePath>;
+
     constructor(params: {
         // intrinsic
         name: string;
@@ -32,21 +34,8 @@ export default class BrickBlock extends BrickModelBlock {
         connectBelow: boolean;
     }) {
         super(params);
-    }
-
-    public get extent(): TBrickExtent {
-        return { width: 0, height: 0 };
-    }
-
-    public get argsCoords(): Record<string, TBrickCoords> {
-        return {};
-    }
-
-    public get SVGpaths(): string[] {
         const argsLength = Object.keys(this._args).length;
-        let result: string[] = [];
-
-        const path = generatePath({
+        this._pathResults = generatePath({
             hasNest: true,
             hasNotchArg: true,
             hasNotchInsTop: this._connectAbove,
@@ -55,8 +44,29 @@ export default class BrickBlock extends BrickModelBlock {
             nestLengthY: 30,
             innerLengthX: 100,
             argHeights: Array.from({ length: argsLength }, () => 17),
-        }).path;
+        });
+    }
 
+    public get extent(): TBrickExtent {
+        return this._pathResults.bBoxBrick.extent;
+    }
+
+    public get argsCoords(): Record<string, TBrickCoords> {
+        const argsKeys = Object.keys(this._args);
+        const result: Record<string, TBrickCoords> = {};
+        argsKeys.forEach((key, index) => {
+            const argX = this._pathResults.bBoxArgs.coords[index].x;
+            const argY = this._pathResults.bBoxArgs.coords[index].y;
+            result[key] = { x: argX, y: argY };
+        });
+
+        return result;
+    }
+
+    public get SVGpaths(): string[] {
+        let result: string[] = [];
+
+        const path = this._pathResults.path;
         result.push(path);
 
         return result;

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -78,4 +78,8 @@ export default class BrickBlock extends BrickModelBlock {
     public get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords } {
         return this._pathResults.bBoxNotchInsTop!;
     }
+
+    public get bBoxNotchInsBot(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxNotchInsBot!;
+    }
 }

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -47,6 +47,10 @@ export default class BrickBlock extends BrickModelBlock {
         });
     }
 
+    public get SVGpath(): string {
+        return this._pathResults.path;
+    }
+
     public get bBoxBrick(): { extent: TBrickExtent; coords: TBrickCoords } {
         return this._pathResults.bBoxBrick;
     }
@@ -67,7 +71,7 @@ export default class BrickBlock extends BrickModelBlock {
         return result;
     }
 
-    public get SVGpath(): string {
-        return this._pathResults.path;
+    public get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxNotchArg!;
     }
 }

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -82,4 +82,8 @@ export default class BrickBlock extends BrickModelBlock {
     public get bBoxNotchInsBot(): { extent: TBrickExtent; coords: TBrickCoords } {
         return this._pathResults.bBoxNotchInsBot!;
     }
+
+    public get bBoxNotchInsNestTop(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxNotchInsNestTop!;
+    }
 }

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -34,7 +34,7 @@ export default class BrickBlock extends BrickModelBlock {
         connectBelow: boolean;
     }) {
         super(params);
-        const argsLength = Object.keys(this._args).length;
+        const argsKeys = Object.keys(this._args);
         this._pathResults = generatePath({
             hasNest: true,
             hasNotchArg: true,
@@ -43,7 +43,7 @@ export default class BrickBlock extends BrickModelBlock {
             scale: this._scale,
             nestLengthY: 30,
             innerLengthX: 100,
-            argHeights: Array.from({ length: argsLength }, () => 17),
+            argHeights: Array.from({ length: argsKeys.length }, () => 17),
         });
     }
 
@@ -51,13 +51,17 @@ export default class BrickBlock extends BrickModelBlock {
         return this._pathResults.bBoxBrick.extent;
     }
 
-    public get argsCoords(): Record<string, TBrickCoords> {
+    public get bBoxArgs(): Record<string, { extent: TBrickExtent; coords: TBrickCoords }> {
         const argsKeys = Object.keys(this._args);
-        const result: Record<string, TBrickCoords> = {};
+        const result: Record<string, { extent: TBrickExtent; coords: TBrickCoords }> = {};
+
         argsKeys.forEach((key, index) => {
+            result[key] = { extent: { width: 0, height: 0 }, coords: { x: 0, y: 0 } };
             const argX = this._pathResults.bBoxArgs.coords[index].x;
             const argY = this._pathResults.bBoxArgs.coords[index].y;
-            result[key] = { x: argX, y: argY };
+
+            result[key].extent = this._pathResults.bBoxArgs.extent;
+            result[key].coords = { x: argX, y: argY };
         });
 
         return result;

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -47,8 +47,8 @@ export default class BrickBlock extends BrickModelBlock {
         });
     }
 
-    public get extent(): TBrickExtent {
-        return this._pathResults.bBoxBrick.extent;
+    public get bBoxBrick(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxBrick;
     }
 
     public get bBoxArgs(): Record<string, { extent: TBrickExtent; coords: TBrickCoords }> {

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -37,7 +37,7 @@ export default class BrickBlock extends BrickModelBlock {
         const argsKeys = Object.keys(this._args);
         this._pathResults = generatePath({
             hasNest: true,
-            hasNotchArg: true,
+            hasNotchArg: false,
             hasNotchInsTop: this._connectAbove,
             hasNotchInsBot: this._connectBelow,
             scale: this._scale,

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -74,4 +74,8 @@ export default class BrickBlock extends BrickModelBlock {
     public get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords } {
         return this._pathResults.bBoxNotchArg!;
     }
+
+    public get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxNotchInsTop!;
+    }
 }

--- a/modules/code-builder/src/brick/design0/BrickData.ts
+++ b/modules/code-builder/src/brick/design0/BrickData.ts
@@ -1,4 +1,4 @@
-import type { TBrickArgDataType, TBrickColor, TBrickExtent } from '@/@types/brick';
+import type { TBrickArgDataType, TBrickColor, TBrickCoords, TBrickExtent } from '@/@types/brick';
 
 import { BrickModelData } from '../model';
 import { generatePath } from './utils/path';
@@ -10,6 +10,8 @@ import { generatePath } from './utils/path';
  * Final class that defines a data brick.
  */
 export default class BrickData extends BrickModelData {
+    readonly _pathResults: ReturnType<typeof generatePath>;
+
     constructor(params: {
         // intrinsic
         name: string;
@@ -26,16 +28,7 @@ export default class BrickData extends BrickModelData {
         scale: number;
     }) {
         super(params);
-    }
-
-    public get extent(): TBrickExtent {
-        return { width: 0, height: 0 };
-    }
-
-    public get SVGpaths(): string[] {
-        let result: string[] = [];
-
-        const path = generatePath({
+        this._pathResults = generatePath({
             hasNest: false,
             hasNotchArg: true,
             hasNotchInsTop: false,
@@ -43,10 +36,18 @@ export default class BrickData extends BrickModelData {
             scale: this._scale,
             innerLengthX: 100,
             argHeights: [],
-        }).path;
+        });
+    }
 
-        result.push(path);
+    public get SVGpath(): string {
+        return this._pathResults.path;
+    }
 
-        return result;
+    public get bBoxBrick(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxBrick;
+    }
+
+    public get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxNotchArg!;
     }
 }

--- a/modules/code-builder/src/brick/design0/BrickExpression.ts
+++ b/modules/code-builder/src/brick/design0/BrickExpression.ts
@@ -10,6 +10,8 @@ import { generatePath } from './utils/path';
  * Final class that defines a expression brick.
  */
 export default class BrickExpression extends BrickModelExpression {
+    readonly _pathResults: ReturnType<typeof generatePath>;
+
     constructor(params: {
         // intrinsic
         name: string;
@@ -31,32 +33,43 @@ export default class BrickExpression extends BrickModelExpression {
         scale: number;
     }) {
         super(params);
-    }
-
-    public get extent(): TBrickExtent {
-        return { width: 0, height: 0 };
-    }
-
-    public get argsCoords(): Record<string, TBrickCoords> {
-        return {};
-    }
-
-    public get SVGpaths(): string[] {
-        const argsLength = Object.keys(this._args).length;
-        let result: string[] = [];
-
-        const path = generatePath({
+        const argsKeys = Object.keys(this._args);
+        this._pathResults = generatePath({
             hasNest: false,
             hasNotchArg: true,
             hasNotchInsTop: false,
             hasNotchInsBot: false,
             scale: this._scale,
             innerLengthX: 100,
-            argHeights: Array.from({ length: argsLength }, () => 17),
-        }).path;
+            argHeights: Array.from({ length: argsKeys.length }, () => 17),
+        });
+    }
 
-        result.push(path);
+    public get SVGpath(): string {
+        return this._pathResults.path;
+    }
+
+    public get bBoxBrick(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxBrick;
+    }
+
+    public get bBoxArgs(): Record<string, { extent: TBrickExtent; coords: TBrickCoords }> {
+        const argsKeys = Object.keys(this._args);
+        const result: Record<string, { extent: TBrickExtent; coords: TBrickCoords }> = {};
+
+        argsKeys.forEach((key, index) => {
+            result[key] = { extent: { width: 0, height: 0 }, coords: { x: 0, y: 0 } };
+            const argX = this._pathResults.bBoxArgs.coords[index].x;
+            const argY = this._pathResults.bBoxArgs.coords[index].y;
+
+            result[key].extent = this._pathResults.bBoxArgs.extent;
+            result[key].coords = { x: argX, y: argY };
+        });
 
         return result;
+    }
+
+    public get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxNotchArg!;
     }
 }

--- a/modules/code-builder/src/brick/design0/BrickStatement.ts
+++ b/modules/code-builder/src/brick/design0/BrickStatement.ts
@@ -10,6 +10,8 @@ import { generatePath } from './utils/path';
  * Final class that defines a statement brick.
  */
 export default class BrickStatement extends BrickModelStatement {
+    readonly _pathResults: ReturnType<typeof generatePath>;
+
     constructor(params: {
         // intrinsic
         name: string;
@@ -32,32 +34,47 @@ export default class BrickStatement extends BrickModelStatement {
         connectBelow: boolean;
     }) {
         super(params);
-    }
-
-    public get extent(): TBrickExtent {
-        return { width: 0, height: 0 };
-    }
-
-    public get argsCoords(): Record<string, TBrickCoords> {
-        return {};
-    }
-
-    public get SVGpaths(): string[] {
-        const argsLength = Object.keys(this._args).length;
-        let result: string[] = [];
-
-        const path = generatePath({
+        const argsKeys = Object.keys(this._args);
+        this._pathResults = generatePath({
             hasNest: false,
             hasNotchArg: false,
             hasNotchInsTop: true,
             hasNotchInsBot: true,
             scale: this._scale,
             innerLengthX: 100,
-            argHeights: Array.from({ length: argsLength }, () => 17),
-        }).path;
+            argHeights: Array.from({ length: argsKeys.length }, () => 17),
+        });
+    }
 
-        result.push(path);
+    public get SVGpath(): string {
+        return this._pathResults.path;
+    }
+
+    public get bBoxBrick(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxBrick;
+    }
+
+    public get bBoxArgs(): Record<string, { extent: TBrickExtent; coords: TBrickCoords }> {
+        const argsKeys = Object.keys(this._args);
+        const result: Record<string, { extent: TBrickExtent; coords: TBrickCoords }> = {};
+
+        argsKeys.forEach((key, index) => {
+            result[key] = { extent: { width: 0, height: 0 }, coords: { x: 0, y: 0 } };
+            const argX = this._pathResults.bBoxArgs.coords[index].x;
+            const argY = this._pathResults.bBoxArgs.coords[index].y;
+
+            result[key].extent = this._pathResults.bBoxArgs.extent;
+            result[key].coords = { x: argX, y: argY };
+        });
 
         return result;
+    }
+
+    public get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxNotchInsTop!;
+    }
+
+    public get bBoxNotchInsBot(): { extent: TBrickExtent; coords: TBrickCoords } {
+        return this._pathResults.bBoxNotchInsBot!;
     }
 }

--- a/modules/code-builder/src/brick/design0/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickBlock.tsx
@@ -8,7 +8,7 @@ export default function (props: { instance: IBrickBlock }): JSX.Element {
   return (
     <g transform={`scale(${instance.scale})`}>
       <path
-        d={instance.SVGpaths[0]}
+        d={instance.SVGpath}
         style={{
           fill: instance.colorBg as string,
           fillOpacity: 1,

--- a/modules/code-builder/src/brick/design0/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickBlock.tsx
@@ -1,8 +1,12 @@
+import type { JSX } from 'react';
 import type { IBrickBlock } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
-export default function (props: { instance: IBrickBlock }): JSX.Element {
+export default function (props: {
+  instance: IBrickBlock;
+  visualIndicators?: JSX.Element;
+}): JSX.Element {
   const { instance } = props;
 
   return (
@@ -18,6 +22,7 @@ export default function (props: { instance: IBrickBlock }): JSX.Element {
           strokeOpacity: 1,
         }}
       />
+      {props.visualIndicators}
     </g>
   );
 }

--- a/modules/code-builder/src/brick/design0/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickBlock.tsx
@@ -3,10 +3,7 @@ import type { IBrickBlock } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
-export default function (props: {
-  instance: IBrickBlock;
-  visualIndicators?: JSX.Element;
-}): JSX.Element {
+export default function (props: { instance: IBrickBlock }): JSX.Element {
   const { instance } = props;
 
   return (
@@ -22,7 +19,6 @@ export default function (props: {
           strokeOpacity: 1,
         }}
       />
-      {props.visualIndicators}
     </g>
   );
 }

--- a/modules/code-builder/src/brick/design0/components/BrickData.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickData.tsx
@@ -1,10 +1,7 @@
 import type { JSX } from 'react';
 import type { IBrickData } from '@/@types/brick';
 
-export default function (props: {
-  instance: IBrickData;
-  visualIndicators?: JSX.Element;
-}): JSX.Element {
+export default function (props: { instance: IBrickData }): JSX.Element {
   const { instance } = props;
 
   return (
@@ -20,7 +17,6 @@ export default function (props: {
           strokeOpacity: 1,
         }}
       />
-      {props.visualIndicators}
     </g>
   );
 }

--- a/modules/code-builder/src/brick/design0/components/BrickData.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickData.tsx
@@ -1,6 +1,10 @@
+import type { JSX } from 'react';
 import type { IBrickData } from '@/@types/brick';
 
-export default function (props: { instance: IBrickData }): JSX.Element {
+export default function (props: {
+  instance: IBrickData;
+  visualIndicators?: JSX.Element;
+}): JSX.Element {
   const { instance } = props;
 
   return (
@@ -16,6 +20,7 @@ export default function (props: { instance: IBrickData }): JSX.Element {
           strokeOpacity: 1,
         }}
       />
+      {props.visualIndicators}
     </g>
   );
 }

--- a/modules/code-builder/src/brick/design0/components/BrickData.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickData.tsx
@@ -6,7 +6,7 @@ export default function (props: { instance: IBrickData }): JSX.Element {
   return (
     <g transform={`scale(${instance.scale})`}>
       <path
-        d={instance.SVGpaths[0]}
+        d={instance.SVGpath}
         style={{
           fill: instance.colorBg as string,
           fillOpacity: 1,

--- a/modules/code-builder/src/brick/design0/components/BrickExpression.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickExpression.tsx
@@ -1,8 +1,12 @@
+import type { JSX } from 'react';
 import type { IBrickExpression } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
-export default function (props: { instance: IBrickExpression }): JSX.Element {
+export default function (props: {
+  instance: IBrickExpression;
+  visualIndicators?: JSX.Element;
+}): JSX.Element {
   const { instance } = props;
 
   return (
@@ -18,6 +22,7 @@ export default function (props: { instance: IBrickExpression }): JSX.Element {
           strokeOpacity: 1,
         }}
       />
+      {props.visualIndicators}
     </g>
   );
 }

--- a/modules/code-builder/src/brick/design0/components/BrickExpression.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickExpression.tsx
@@ -8,7 +8,7 @@ export default function (props: { instance: IBrickExpression }): JSX.Element {
   return (
     <g transform={`scale(${instance.scale})`}>
       <path
-        d={instance.SVGpaths[0]}
+        d={instance.SVGpath}
         style={{
           fill: instance.colorBg as string,
           fillOpacity: 1,

--- a/modules/code-builder/src/brick/design0/components/BrickExpression.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickExpression.tsx
@@ -3,10 +3,7 @@ import type { IBrickExpression } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
-export default function (props: {
-  instance: IBrickExpression;
-  visualIndicators?: JSX.Element;
-}): JSX.Element {
+export default function (props: { instance: IBrickExpression }): JSX.Element {
   const { instance } = props;
 
   return (
@@ -22,7 +19,6 @@ export default function (props: {
           strokeOpacity: 1,
         }}
       />
-      {props.visualIndicators}
     </g>
   );
 }

--- a/modules/code-builder/src/brick/design0/components/BrickStatement.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickStatement.tsx
@@ -1,8 +1,12 @@
+import type { JSX } from 'react';
 import type { IBrickStatement } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
-export default function (props: { instance: IBrickStatement }): JSX.Element {
+export default function (props: {
+  instance: IBrickStatement;
+  visualIndicators?: JSX.Element;
+}): JSX.Element {
   const { instance } = props;
 
   return (
@@ -18,6 +22,7 @@ export default function (props: { instance: IBrickStatement }): JSX.Element {
           strokeOpacity: 1,
         }}
       />
+      {props.visualIndicators}
     </g>
   );
 }

--- a/modules/code-builder/src/brick/design0/components/BrickStatement.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickStatement.tsx
@@ -3,10 +3,7 @@ import type { IBrickStatement } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
-export default function (props: {
-  instance: IBrickStatement;
-  visualIndicators?: JSX.Element;
-}): JSX.Element {
+export default function (props: { instance: IBrickStatement }): JSX.Element {
   const { instance } = props;
 
   return (
@@ -22,7 +19,6 @@ export default function (props: {
           strokeOpacity: 1,
         }}
       />
-      {props.visualIndicators}
     </g>
   );
 }

--- a/modules/code-builder/src/brick/design0/components/BrickStatement.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickStatement.tsx
@@ -8,7 +8,7 @@ export default function (props: { instance: IBrickStatement }): JSX.Element {
   return (
     <g transform={`scale(${instance.scale})`}>
       <path
-        d={instance.SVGpaths[0]}
+        d={instance.SVGpath}
         style={{
           fill: instance.colorBg as string,
           fillOpacity: 1,

--- a/modules/code-builder/src/brick/design0/stories/BrickExpression.stories.ts
+++ b/modules/code-builder/src/brick/design0/stories/BrickExpression.stories.ts
@@ -9,19 +9,6 @@ export default {
 
 // -------------------------------------------------------------------------------------------------
 
-export const NoArgs: Story = {
-    args: {
-        Component: CBrickExpression,
-        prototype: MBrickExpression,
-        label: 'Expression',
-        args: [],
-        colorBg: 'yellow',
-        colorFg: 'black',
-        outline: 'red',
-        scale: 1,
-    },
-};
-
 export const WithArgs: Story = {
     args: {
         Component: CBrickExpression,

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -482,17 +482,20 @@ function _getBBoxArgs(): {
     extent: { width: number; height: number };
     coords: { x: number; y: number }[];
 } {
+    const offsetX = strokeWidth + notchArgLengthX + _innerLengthX - notchArgLengthX + strokeWidth;
+    const firstOffsetY = strokeWidth + cornerRadius + 1 + strokeWidth;
+
     return {
         extent: {
             width: notchArgLengthX,
-            height: notchArgLengthY,
+            height: 10 - 2 * strokeWidth,
         },
-        coords: [
-            {
-                x: 0,
-                y: 0,
-            },
-        ],
+        coords: _argsLengthY.map((_, index) => {
+            return {
+                x: offsetX,
+                y: firstOffsetY + index * notchArgLengthY,
+            };
+        }),
     };
 }
 
@@ -588,7 +591,6 @@ export function generatePath(
     };
 
     if (print) console.log(results);
-    console.log(results.path);
 
     return results;
 }

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -393,12 +393,17 @@ function _getBBoxNotchInsTop(): {
 } {
     return {
         extent: {
-            width: notchInsLengthX,
+            width: notchInsLengthX - 2 * strokeWidth,
             height: notchInsLengthY,
         },
         coords: {
-            x: 0,
-            y: 0,
+            x:
+                strokeWidth +
+                (_hasNotchArg ? notchArgLengthX : 0) +
+                cornerRadius +
+                notchInsOffsetX +
+                strokeWidth,
+            y: strokeWidth + notchInsLengthY - strokeWidth,
         },
     };
 }

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -403,7 +403,7 @@ function _getBBoxNotchInsTop(): {
                 cornerRadius +
                 notchInsOffsetX +
                 strokeWidth,
-            y: strokeWidth + notchInsLengthY - strokeWidth,
+            y: 0,
         },
     };
 }
@@ -419,7 +419,7 @@ function _getBBoxNotchInsBot(): {
 } {
     return {
         extent: {
-            width: notchInsLengthX - 4 * strokeWidth,
+            width: notchInsLengthX - 2 * strokeWidth,
             height: strokeWidth + notchInsLengthY - strokeWidth,
         },
         coords: {
@@ -464,10 +464,8 @@ function _getBBoxNotchInsNestTop(): {
                 (_hasNotchArg ? notchArgLengthX : 0) +
                 cornerRadius +
                 notchInsOffsetX +
-                notchInsLengthX +
-                4 * strokeWidth -
+                notchInsLengthX -
                 strokeWidth,
-
             y: offsetY,
         },
     };
@@ -484,6 +482,10 @@ function _getBBoxArgs(): {
 } {
     const offsetX = strokeWidth + notchArgLengthX + _innerLengthX - notchArgLengthX + strokeWidth;
     const firstOffsetY = strokeWidth + cornerRadius + 1 + strokeWidth;
+    const argSectionLengthYMin = cornerRadius * 2 + notchArgLengthY;
+    const argsLength = _argsLengthY.map((sectionLengthY) =>
+        Math.max(argSectionLengthYMin, sectionLengthY),
+    );
 
     return {
         extent: {
@@ -493,7 +495,7 @@ function _getBBoxArgs(): {
         coords: _argsLengthY.map((_, index) => {
             return {
                 x: offsetX,
-                y: firstOffsetY + index * notchArgLengthY,
+                y: firstOffsetY + (index === 0 ? 0 : argsLength[index - 1]),
             };
         }),
     };

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -1,6 +1,7 @@
 // == constants ====================================================================================
 
 const cornerRadius = 4;
+const strokeWidth = 0.5;
 
 const notchInsOffsetX = 4;
 const notchInsLengthX = 10;
@@ -334,13 +335,27 @@ function _getBBoxBrick(): {
     extent: { width: number; height: number };
     coords: { x: number; y: number };
 } {
+    const argSectionLengthYMin = cornerRadius * 2 + notchArgLengthY;
+    const argsLength = _argsLengthY
+        .map((sectionLengthY) => Math.max(argSectionLengthYMin, sectionLengthY))
+        .reduce((a, b) => a + b, 0);
+
+    let height =
+        strokeWidth +
+        (argsLength !== 0 ? argsLength : 2 * cornerRadius + notchArgLengthY) +
+        strokeWidth;
+
+    if (_hasNest) {
+        height += _nestLengthY + strokeWidth * 4 + 2 * cornerRadius + notchArgLengthY;
+    }
+
     return {
         extent: {
-            width: _innerLengthX,
-            height: _argsLengthY.reduce((a, b) => a + b, 0),
+            width: strokeWidth + _innerLengthX + strokeWidth,
+            height: height,
         },
         coords: {
-            x: 0,
+            x: _hasNotchArg ? notchArgLengthX : 0,
             y: 0,
         },
     };

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -372,12 +372,12 @@ function _getBBoxNotchArg(): {
 } {
     return {
         extent: {
-            width: notchArgLengthX,
-            height: notchArgLengthY - 2,
+            width: _hasNotchArg ? notchArgLengthX : 0,
+            height: _hasNotchArg ? strokeWidth + 8 + strokeWidth : 0,
         },
         coords: {
             x: 0,
-            y: 0,
+            y: _hasNotchArg ? 6 : 0,
         },
     };
 }
@@ -560,6 +560,7 @@ export function generatePath(
     };
 
     if (print) console.log(results);
+    console.log(results.path);
 
     return results;
 }

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -495,7 +495,9 @@ function _getBBoxArgs(): {
         coords: _argsLengthY.map((_, index) => {
             return {
                 x: offsetX,
-                y: firstOffsetY + (index === 0 ? 0 : argsLength[index - 1]),
+                y:
+                    firstOffsetY +
+                    (index === 0 ? 0 : argsLength.slice(0, index).reduce((a, b) => a + b, 0)),
             };
         }),
     };

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -592,7 +592,7 @@ export function generatePath(
         bBoxArgs: _getBBoxArgs(),
     };
 
-    if (print) console.log(results);
+    if (print || import.meta.env.DEV) console.log(results);
 
     return results;
 }

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -480,7 +480,12 @@ function _getBBoxArgs(): {
     extent: { width: number; height: number };
     coords: { x: number; y: number }[];
 } {
-    const offsetX = strokeWidth + notchArgLengthX + _innerLengthX - notchArgLengthX + strokeWidth;
+    const offsetX =
+        strokeWidth +
+        (_hasNotchArg ? notchArgLengthX : 0) +
+        _innerLengthX -
+        notchArgLengthX +
+        strokeWidth;
     const firstOffsetY = strokeWidth + cornerRadius + 1 + strokeWidth;
     const argSectionLengthYMin = cornerRadius * 2 + notchArgLengthY;
     const argsLength = _argsLengthY.map((sectionLengthY) =>

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -443,14 +443,32 @@ function _getBBoxNotchInsNestTop(): {
     extent: { width: number; height: number };
     coords: { x: number; y: number };
 } {
+    const argSectionLengthYMin = cornerRadius * 2 + notchArgLengthY;
+    const argsLength = _argsLengthY
+        .map((sectionLengthY) => Math.max(argSectionLengthYMin, sectionLengthY))
+        .reduce((a, b) => a + b, 0);
+
+    const offsetY =
+        strokeWidth +
+        (argsLength !== 0 ? argsLength : 2 * cornerRadius + notchArgLengthY) +
+        strokeWidth;
+
     return {
         extent: {
-            width: notchInsLengthX,
+            width: notchInsLengthX - 2 * strokeWidth,
             height: notchInsLengthY,
         },
         coords: {
-            x: 0,
-            y: 0,
+            x:
+                strokeWidth +
+                (_hasNotchArg ? notchArgLengthX : 0) +
+                cornerRadius +
+                notchInsOffsetX +
+                notchInsLengthX +
+                4 * strokeWidth -
+                strokeWidth,
+
+            y: offsetY,
         },
     };
 }

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -599,7 +599,7 @@ export function generatePath(
         bBoxArgs: _getBBoxArgs(),
     };
 
-    if (print || import.meta.env.DEV) console.log(results);
+    if (print) console.log(results);
 
     return results;
 }

--- a/modules/code-builder/src/brick/design0/utils/path.ts
+++ b/modules/code-builder/src/brick/design0/utils/path.ts
@@ -419,12 +419,17 @@ function _getBBoxNotchInsBot(): {
 } {
     return {
         extent: {
-            width: notchInsLengthX,
-            height: notchInsLengthY,
+            width: notchInsLengthX - 4 * strokeWidth,
+            height: strokeWidth + notchInsLengthY - strokeWidth,
         },
         coords: {
-            x: 0,
-            y: 0,
+            x:
+                strokeWidth +
+                (_hasNotchArg ? notchArgLengthX : 0) +
+                cornerRadius +
+                notchInsOffsetX +
+                strokeWidth,
+            y: _getBBoxBrick().extent.height,
         },
     };
 }

--- a/modules/code-builder/src/brick/design0/utils/spec/path.spec.ts
+++ b/modules/code-builder/src/brick/design0/utils/spec/path.spec.ts
@@ -376,20 +376,154 @@ describe('Code Builder: Brick > Design 0 > Utility: Path', () => {
     });
 
     describe('Bounding Box Calculation', () => {
-        it.todo('evaluates brick bounding box for brick with no argument notch');
+        it('evaluates brick bounding box for brick with no argument notch', () => {
+            const { bBoxBrick } = generatePath({
+                hasNest: false,
+                hasNotchArg: false,
+                hasNotchInsTop: true,
+                hasNotchInsBot: true,
+                scale: 1,
+                innerLengthX: 100,
+                argHeights: [],
+            });
+            expect(bBoxBrick.extent.height).toBe(21);
+            expect(bBoxBrick.extent.width).toBe(101);
+            expect(bBoxBrick.coords.x).toBe(0);
+            expect(bBoxBrick.coords.y).toBe(0);
+        });
 
-        it.todo('evaluates brick bounding box for brick with argument notch');
+        it('evaluates brick bounding box for brick with argument notch', () => {
+            const { bBoxBrick } = generatePath({
+                hasNest: false,
+                hasNotchArg: true,
+                hasNotchInsTop: false,
+                hasNotchInsBot: false,
+                scale: 1,
+                innerLengthX: 100,
+                argHeights: [],
+            });
+            expect(bBoxBrick.extent.height).toBe(21);
+            expect(bBoxBrick.extent.width).toBe(101);
+            expect(bBoxBrick.coords.x).toBe(8);
+            expect(bBoxBrick.coords.y).toBe(0);
+        });
 
-        it.todo('evaluates argument notch bounding box for brick');
+        it('evaluates argument notch bounding box for brick', () => {
+            const { bBoxNotchArg } = generatePath({
+                hasNest: false,
+                hasNotchArg: true,
+                hasNotchInsTop: false,
+                hasNotchInsBot: false,
+                scale: 1,
+                innerLengthX: 100,
+                argHeights: [],
+            });
+            expect(bBoxNotchArg?.extent.height).toBe(9);
+            expect(bBoxNotchArg?.extent.width).toBe(8);
+            expect(bBoxNotchArg?.coords.x).toBe(0);
+            expect(bBoxNotchArg?.coords.y).toBe(6);
+        });
 
-        it.todo('evaluates top instruction notch bounding box');
+        it('evaluates top instruction notch bounding box', () => {
+            const { bBoxNotchInsTop } = generatePath({
+                hasNest: false,
+                hasNotchArg: false,
+                hasNotchInsTop: true,
+                hasNotchInsBot: true,
+                scale: 1,
+                innerLengthX: 100,
+                argHeights: [],
+            });
+            expect(bBoxNotchInsTop?.extent.height).toBe(2);
+            expect(bBoxNotchInsTop?.extent.width).toBe(9);
+            expect(bBoxNotchInsTop?.coords.x).toBe(9);
+            expect(bBoxNotchInsTop?.coords.y).toBe(0);
+        });
 
-        it.todo('evaluates bottom instruction notch bounding box for non-nesting brick');
+        it('evaluates bottom instruction notch bounding box for non-nesting brick', () => {
+            const { bBoxNotchInsBot } = generatePath({
+                hasNest: false,
+                hasNotchArg: false,
+                hasNotchInsTop: true,
+                hasNotchInsBot: true,
+                scale: 1,
+                innerLengthX: 100,
+                argHeights: [],
+            });
+            expect(bBoxNotchInsBot?.extent.height).toBe(2);
+            expect(bBoxNotchInsBot?.extent.width).toBe(9);
+            expect(bBoxNotchInsBot?.coords.x).toBe(9);
+            expect(bBoxNotchInsBot?.coords.y).toBe(21);
+        });
 
-        it.todo('evaluates bottom instruction notch bounding box for nesting brick');
+        it('evaluates bottom instruction notch bounding box for nesting brick', () => {
+            const { bBoxNotchInsBot } = generatePath({
+                hasNest: true,
+                hasNotchArg: false,
+                hasNotchInsTop: true,
+                hasNotchInsBot: true,
+                scale: 1,
+                nestLengthY: 30,
+                innerLengthX: 100,
+                argHeights: [],
+            });
+            expect(bBoxNotchInsBot?.extent.height).toBe(2);
+            expect(bBoxNotchInsBot?.extent.width).toBe(9);
+            expect(bBoxNotchInsBot?.coords.x).toBe(9);
+            expect(bBoxNotchInsBot?.coords.y).toBe(73);
+        });
 
-        it.todo('evaluates inner top instruction notch bounding box for nesting brick');
+        it('evaluates inner top instruction notch bounding box for nesting brick', () => {
+            const { bBoxNotchInsNestTop } = generatePath({
+                hasNest: true,
+                hasNotchArg: false,
+                hasNotchInsTop: true,
+                hasNotchInsBot: true,
+                scale: 1,
+                nestLengthY: 30,
+                innerLengthX: 100,
+                argHeights: [],
+            });
+            expect(bBoxNotchInsNestTop?.extent.height).toBe(2);
+            expect(bBoxNotchInsNestTop?.extent.width).toBe(9);
+            expect(bBoxNotchInsNestTop?.coords.x).toBe(18);
+            expect(bBoxNotchInsNestTop?.coords.y).toBe(21);
+        });
 
-        it.todo('evaluates bounding boxes for arguments');
+        it('evaluates inner top instruction notch bounding box for nesting brick', () => {
+            const { bBoxNotchInsNestTop } = generatePath({
+                hasNest: true,
+                hasNotchArg: false,
+                hasNotchInsTop: true,
+                hasNotchInsBot: true,
+                scale: 1,
+                nestLengthY: 30,
+                innerLengthX: 100,
+                argHeights: [],
+            });
+            expect(bBoxNotchInsNestTop?.extent.height).toBe(2);
+            expect(bBoxNotchInsNestTop?.extent.width).toBe(9);
+            expect(bBoxNotchInsNestTop?.coords.x).toBe(18);
+            expect(bBoxNotchInsNestTop?.coords.y).toBe(21);
+        });
+
+        it('evaluates bounding boxes for arguments', () => {
+            const { bBoxArgs } = generatePath({
+                hasNest: false,
+                hasNotchArg: false,
+                hasNotchInsTop: true,
+                hasNotchInsBot: true,
+                scale: 1,
+                innerLengthX: 100,
+                argHeights: [17, 30, 40],
+            });
+            expect(bBoxArgs.extent.height).toBe(9);
+            expect(bBoxArgs.extent.width).toBe(8);
+            expect(bBoxArgs.coords).toStrictEqual([
+                { x: 93, y: 6 },
+                { x: 93, y: 26 },
+                { x: 93, y: 56 },
+            ]);
+        });
     });
 });

--- a/modules/code-builder/src/brick/model.ts
+++ b/modules/code-builder/src/brick/model.ts
@@ -135,6 +135,8 @@ abstract class BrickModelArgument extends BrickModel implements IBrickArgument {
     public get dataType(): TBrickArgDataType {
         return this._dataType;
     }
+
+    public abstract get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords };
 }
 
 /**
@@ -203,6 +205,10 @@ abstract class BrickModelInstruction extends BrickModel implements IBrickInstruc
         return this._connectBelow;
     }
 
+    public abstract get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords };
+
+    public abstract get bBoxNotchInsBot(): { extent: TBrickExtent; coords: TBrickCoords };
+
     public abstract get bBoxArgs(): Record<string, { extent: TBrickExtent; coords: TBrickCoords }>;
 }
 
@@ -251,8 +257,6 @@ export abstract class BrickModelData extends BrickModelArgument implements IBric
     public get input(): 'boolean' | 'number' | 'string' | 'options' | undefined {
         return this._input;
     }
-
-    public abstract get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords };
 }
 
 /**
@@ -307,8 +311,6 @@ export abstract class BrickModelExpression extends BrickModelArgument implements
     }
 
     public abstract get bBoxArgs(): Record<string, { extent: TBrickExtent; coords: TBrickCoords }>;
-
-    public abstract get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords };
 }
 
 /**
@@ -340,10 +342,6 @@ export abstract class BrickModelStatement extends BrickModelInstruction implemen
     }) {
         super({ ...params, type: 'statement' });
     }
-
-    public abstract get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords };
-
-    public abstract get bBoxNotchInsBot(): { extent: TBrickExtent; coords: TBrickCoords };
 }
 
 /**
@@ -378,12 +376,6 @@ export abstract class BrickModelBlock extends BrickModelInstruction implements I
     }) {
         super({ ...params, type: 'block' });
     }
-
-    public abstract get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords };
-
-    public abstract get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords };
-
-    public abstract get bBoxNotchInsBot(): { extent: TBrickExtent; coords: TBrickCoords };
 
     public abstract get bBoxNotchInsNestTop(): { extent: TBrickExtent; coords: TBrickCoords };
 }

--- a/modules/code-builder/src/brick/model.ts
+++ b/modules/code-builder/src/brick/model.ts
@@ -340,6 +340,8 @@ export abstract class BrickModelStatement extends BrickModelInstruction implemen
     }) {
         super({ ...params, type: 'statement' });
     }
+
+    public abstract get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords };
 }
 
 /**
@@ -376,4 +378,6 @@ export abstract class BrickModelBlock extends BrickModelInstruction implements I
     }
 
     public abstract get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords };
+
+    public abstract get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords };
 }

--- a/modules/code-builder/src/brick/model.ts
+++ b/modules/code-builder/src/brick/model.ts
@@ -384,4 +384,6 @@ export abstract class BrickModelBlock extends BrickModelInstruction implements I
     public abstract get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords };
 
     public abstract get bBoxNotchInsBot(): { extent: TBrickExtent; coords: TBrickCoords };
+
+    public abstract get bBoxNotchInsNestTop(): { extent: TBrickExtent; coords: TBrickCoords };
 }

--- a/modules/code-builder/src/brick/model.ts
+++ b/modules/code-builder/src/brick/model.ts
@@ -101,7 +101,7 @@ abstract class BrickModel implements IBrick {
         return this._scale;
     }
 
-    public abstract get extent(): TBrickExtent;
+    public abstract get bBoxBrick(): { extent: TBrickExtent; coords: TBrickCoords };
 
     public abstract get SVGpaths(): string[];
 }

--- a/modules/code-builder/src/brick/model.ts
+++ b/modules/code-builder/src/brick/model.ts
@@ -342,6 +342,8 @@ export abstract class BrickModelStatement extends BrickModelInstruction implemen
     }
 
     public abstract get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords };
+
+    public abstract get bBoxNotchInsBot(): { extent: TBrickExtent; coords: TBrickCoords };
 }
 
 /**
@@ -380,4 +382,6 @@ export abstract class BrickModelBlock extends BrickModelInstruction implements I
     public abstract get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords };
 
     public abstract get bBoxNotchInsTop(): { extent: TBrickExtent; coords: TBrickCoords };
+
+    public abstract get bBoxNotchInsBot(): { extent: TBrickExtent; coords: TBrickCoords };
 }

--- a/modules/code-builder/src/brick/model.ts
+++ b/modules/code-builder/src/brick/model.ts
@@ -155,8 +155,6 @@ abstract class BrickModelInstruction extends BrickModel implements IBrickInstruc
     protected _connectAbove: boolean;
     protected _connectBelow: boolean;
 
-    public argsExtent: Record<string, TBrickExtent> = {};
-
     constructor(params: {
         // intrinsic
         name: string;
@@ -205,7 +203,10 @@ abstract class BrickModelInstruction extends BrickModel implements IBrickInstruc
         return this._connectBelow;
     }
 
-    public abstract get argsCoords(): Record<string, TBrickCoords>;
+    public abstract get bBoxArgs(): {
+        extent: Record<string, TBrickExtent>;
+        coords: Record<string, TBrickCoords>;
+    };
 }
 
 // -- public classes -------------------------------------------------------------------------------
@@ -270,8 +271,6 @@ export abstract class BrickModelExpression extends BrickModelArgument implements
         }
     >;
 
-    public argsExtent: Record<string, TBrickExtent> = {};
-
     constructor(params: {
         // intrinsic
         name: string;
@@ -308,7 +307,10 @@ export abstract class BrickModelExpression extends BrickModelArgument implements
         return this._args;
     }
 
-    public abstract get argsCoords(): Record<string, TBrickCoords>;
+    public abstract get bBoxArgs(): {
+        extent: Record<string, TBrickExtent>;
+        coords: Record<string, TBrickCoords>;
+    };
 }
 
 /**

--- a/modules/code-builder/src/brick/model.ts
+++ b/modules/code-builder/src/brick/model.ts
@@ -103,7 +103,7 @@ abstract class BrickModel implements IBrick {
 
     public abstract get bBoxBrick(): { extent: TBrickExtent; coords: TBrickCoords };
 
-    public abstract get SVGpaths(): string[];
+    public abstract get SVGpath(): string;
 }
 
 /**

--- a/modules/code-builder/src/brick/model.ts
+++ b/modules/code-builder/src/brick/model.ts
@@ -251,6 +251,8 @@ export abstract class BrickModelData extends BrickModelArgument implements IBric
     public get input(): 'boolean' | 'number' | 'string' | 'options' | undefined {
         return this._input;
     }
+
+    public abstract get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords };
 }
 
 /**
@@ -305,6 +307,8 @@ export abstract class BrickModelExpression extends BrickModelArgument implements
     }
 
     public abstract get bBoxArgs(): Record<string, { extent: TBrickExtent; coords: TBrickCoords }>;
+
+    public abstract get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords };
 }
 
 /**
@@ -370,4 +374,6 @@ export abstract class BrickModelBlock extends BrickModelInstruction implements I
     }) {
         super({ ...params, type: 'block' });
     }
+
+    public abstract get bBoxNotchArg(): { extent: TBrickExtent; coords: TBrickCoords };
 }

--- a/modules/code-builder/src/brick/model.ts
+++ b/modules/code-builder/src/brick/model.ts
@@ -203,10 +203,7 @@ abstract class BrickModelInstruction extends BrickModel implements IBrickInstruc
         return this._connectBelow;
     }
 
-    public abstract get bBoxArgs(): {
-        extent: Record<string, TBrickExtent>;
-        coords: Record<string, TBrickCoords>;
-    };
+    public abstract get bBoxArgs(): Record<string, { extent: TBrickExtent; coords: TBrickCoords }>;
 }
 
 // -- public classes -------------------------------------------------------------------------------
@@ -307,10 +304,7 @@ export abstract class BrickModelExpression extends BrickModelArgument implements
         return this._args;
     }
 
-    public abstract get bBoxArgs(): {
-        extent: Record<string, TBrickExtent>;
-        coords: Record<string, TBrickCoords>;
-    };
+    public abstract get bBoxArgs(): Record<string, { extent: TBrickExtent; coords: TBrickCoords }>;
 }
 
 /**

--- a/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
@@ -115,7 +115,8 @@ export default function (props: {
 
   return (
     <BrickWrapper>
-      <Component instance={instance} visualIndicators={<VisualIndicators />} />
+      <Component instance={instance} />
+      <VisualIndicators />
     </BrickWrapper>
   );
 }

--- a/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
@@ -1,6 +1,6 @@
-import type { IBrickBlock, TBrickArgDataType, TBrickColor } from '@/@types/brick';
-
 import BrickWrapper from './BrickWrapper';
+import type { JSX } from 'react';
+import type { IBrickBlock, TBrickArgDataType, TBrickColor } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 

--- a/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
@@ -90,6 +90,16 @@ export default function (props: {
         fill="green"
         opacity={0.8}
       />
+
+      {/* Top instruction notch bounding box */}
+      <rect
+        x={instance.bBoxNotchInsTop.coords.x}
+        y={instance.bBoxNotchInsTop.coords.y}
+        height={instance.bBoxNotchInsTop.extent.height}
+        width={instance.bBoxNotchInsTop.extent.width}
+        fill="green"
+        opacity={0.9}
+      />
     </>
   );
 

--- a/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
@@ -64,6 +64,7 @@ export default function (props: {
         opacity={0.2}
       /> */}
 
+      {/* Right args bounding box */}
       {Object.keys(instance.bBoxArgs).map((name, i) => {
         const arg = instance.bBoxArgs[name];
 
@@ -79,6 +80,16 @@ export default function (props: {
           />
         );
       })}
+
+      {/* Left notch bounding box */}
+      <rect
+        x={instance.bBoxNotchArg.coords.x}
+        y={instance.bBoxNotchArg.coords.y}
+        height={instance.bBoxNotchArg.extent.height}
+        width={instance.bBoxNotchArg.extent.width}
+        fill="green"
+        opacity={0.8}
+      />
     </>
   );
 

--- a/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
@@ -5,7 +5,7 @@ import BrickWrapper from './BrickWrapper';
 // -------------------------------------------------------------------------------------------------
 
 export default function (props: {
-  Component: (props: { instance: IBrickBlock }) => JSX.Element;
+  Component: (props: { instance: IBrickBlock; visualIndicators?: JSX.Element }) => JSX.Element;
   prototype: new (params: {
     name: string;
     label: string;
@@ -52,9 +52,39 @@ export default function (props: {
     name: '',
   });
 
+  const VisualIndicators = () => (
+    <>
+      {/* Overall Bounding Box of the Brick */}
+      {/* <rect
+        x={instance.bBoxBrick.coords.x}
+        y={instance.bBoxBrick.coords.y}
+        height={instance.bBoxBrick.extent.height}
+        width={instance.bBoxBrick.extent.width}
+        fill="green"
+        opacity={0.2}
+      /> */}
+
+      {Object.keys(instance.bBoxArgs).map((name, i) => {
+        const arg = instance.bBoxArgs[name];
+
+        return (
+          <rect
+            key={i}
+            x={arg.coords.x}
+            y={arg.coords.y}
+            height={arg.extent.height}
+            width={arg.extent.width}
+            fill="green"
+            opacity={0.8}
+          />
+        );
+      })}
+    </>
+  );
+
   return (
     <BrickWrapper>
-      <Component instance={instance} />
+      <Component instance={instance} visualIndicators={<VisualIndicators />} />
     </BrickWrapper>
   );
 }

--- a/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
@@ -100,6 +100,16 @@ export default function (props: {
         fill="green"
         opacity={0.9}
       />
+
+      {/* Bottom instruction notch bounding box */}
+      <rect
+        x={instance.bBoxNotchInsBot.coords.x}
+        y={instance.bBoxNotchInsBot.coords.y}
+        height={instance.bBoxNotchInsBot.extent.height}
+        width={instance.bBoxNotchInsBot.extent.width}
+        fill="green"
+        opacity={0.9}
+      />
     </>
   );
 

--- a/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
@@ -110,6 +110,16 @@ export default function (props: {
         fill="green"
         opacity={0.9}
       />
+
+      {/* Top instruction notch inside nesting bounding box */}
+      <rect
+        x={instance.bBoxNotchInsNestTop.coords.x}
+        y={instance.bBoxNotchInsNestTop.coords.y}
+        height={instance.bBoxNotchInsNestTop.extent.height}
+        width={instance.bBoxNotchInsNestTop.extent.width}
+        fill="green"
+        opacity={0.9}
+      />
     </>
   );
 

--- a/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
@@ -81,16 +81,6 @@ export default function (props: {
         );
       })}
 
-      {/* Left notch bounding box */}
-      <rect
-        x={instance.bBoxNotchArg.coords.x}
-        y={instance.bBoxNotchArg.coords.y}
-        height={instance.bBoxNotchArg.extent.height}
-        width={instance.bBoxNotchArg.extent.width}
-        fill="green"
-        opacity={0.8}
-      />
-
       {/* Top instruction notch bounding box */}
       <rect
         x={instance.bBoxNotchInsTop.coords.x}

--- a/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickBlock.tsx
@@ -55,14 +55,14 @@ export default function (props: {
   const VisualIndicators = () => (
     <>
       {/* Overall Bounding Box of the Brick */}
-      {/* <rect
+      <rect
         x={instance.bBoxBrick.coords.x}
         y={instance.bBoxBrick.coords.y}
         height={instance.bBoxBrick.extent.height}
         width={instance.bBoxBrick.extent.width}
-        fill="green"
-        opacity={0.2}
-      /> */}
+        fill="black"
+        opacity={0.25}
+      />
 
       {/* Right args bounding box */}
       {Object.keys(instance.bBoxArgs).map((name, i) => {

--- a/modules/code-builder/src/brick/stories/components/BrickData.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickData.tsx
@@ -42,14 +42,14 @@ export default function (props: {
   const VisualIndicators = () => (
     <>
       {/* Overall Bounding Box of the Brick */}
-      {/* <rect
+      <rect
         x={instance.bBoxBrick.coords.x}
         y={instance.bBoxBrick.coords.y}
         height={instance.bBoxBrick.extent.height}
         width={instance.bBoxBrick.extent.width}
-        fill="green"
-        opacity={0.2}
-      /> */}
+        fill="black"
+        opacity={0.25}
+      />
 
       {/* Left notch bounding box */}
       <rect

--- a/modules/code-builder/src/brick/stories/components/BrickData.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickData.tsx
@@ -65,7 +65,8 @@ export default function (props: {
 
   return (
     <BrickWrapper>
-      <Component instance={instance} visualIndicators={<VisualIndicators />} />
+      <Component instance={instance} />
+      <VisualIndicators />
     </BrickWrapper>
   );
 }

--- a/modules/code-builder/src/brick/stories/components/BrickData.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickData.tsx
@@ -1,11 +1,11 @@
-import type { IBrickData, TBrickArgDataType, TBrickColor } from '@/@types/brick';
-
 import BrickWrapper from './BrickWrapper';
+import type { JSX } from 'react';
+import type { IBrickData, TBrickArgDataType, TBrickColor } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
 export default function (props: {
-  Component: (props: { instance: IBrickData }) => JSX.Element;
+  Component: (props: { instance: IBrickData; visualIndicators?: JSX.Element }) => JSX.Element;
   prototype: new (params: {
     name: string;
     label: string;
@@ -39,9 +39,33 @@ export default function (props: {
     name: '',
   });
 
+  const VisualIndicators = () => (
+    <>
+      {/* Overall Bounding Box of the Brick */}
+      {/* <rect
+        x={instance.bBoxBrick.coords.x}
+        y={instance.bBoxBrick.coords.y}
+        height={instance.bBoxBrick.extent.height}
+        width={instance.bBoxBrick.extent.width}
+        fill="green"
+        opacity={0.2}
+      /> */}
+
+      {/* Left notch bounding box */}
+      <rect
+        x={instance.bBoxNotchArg.coords.x}
+        y={instance.bBoxNotchArg.coords.y}
+        height={instance.bBoxNotchArg.extent.height}
+        width={instance.bBoxNotchArg.extent.width}
+        fill="green"
+        opacity={0.8}
+      />
+    </>
+  );
+
   return (
     <BrickWrapper>
-      <Component instance={instance} />
+      <Component instance={instance} visualIndicators={<VisualIndicators />} />
     </BrickWrapper>
   );
 }

--- a/modules/code-builder/src/brick/stories/components/BrickExpression.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickExpression.tsx
@@ -93,7 +93,8 @@ export default function (props: {
 
   return (
     <BrickWrapper>
-      <Component instance={instance} visualIndicators={<VisualIndicators />} />
+      <Component instance={instance} />
+      <VisualIndicators />
     </BrickWrapper>
   );
 }

--- a/modules/code-builder/src/brick/stories/components/BrickExpression.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickExpression.tsx
@@ -53,14 +53,14 @@ export default function (props: {
   const VisualIndicators = () => (
     <>
       {/* Overall Bounding Box of the Brick */}
-      {/* <rect
+      <rect
         x={instance.bBoxBrick.coords.x}
         y={instance.bBoxBrick.coords.y}
         height={instance.bBoxBrick.extent.height}
         width={instance.bBoxBrick.extent.width}
-        fill="green"
-        opacity={0.2}
-      /> */}
+        fill="black"
+        opacity={0.25}
+      />
 
       {/* Right args bounding box */}
       {Object.keys(instance.bBoxArgs).map((name, i) => {

--- a/modules/code-builder/src/brick/stories/components/BrickExpression.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickExpression.tsx
@@ -1,11 +1,11 @@
-import type { IBrickExpression, TBrickArgDataType, TBrickColor } from '@/@types/brick';
-
 import BrickWrapper from './BrickWrapper';
+import type { JSX } from 'react';
+import type { IBrickExpression, TBrickArgDataType, TBrickColor } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
 export default function (props: {
-  Component: (props: { instance: IBrickExpression }) => JSX.Element;
+  Component: (props: { instance: IBrickExpression; visualIndicators?: JSX.Element }) => JSX.Element;
   prototype: new (params: {
     name: string;
     label: string;
@@ -50,9 +50,50 @@ export default function (props: {
     name: '',
   });
 
+  const VisualIndicators = () => (
+    <>
+      {/* Overall Bounding Box of the Brick */}
+      {/* <rect
+        x={instance.bBoxBrick.coords.x}
+        y={instance.bBoxBrick.coords.y}
+        height={instance.bBoxBrick.extent.height}
+        width={instance.bBoxBrick.extent.width}
+        fill="green"
+        opacity={0.2}
+      /> */}
+
+      {/* Right args bounding box */}
+      {Object.keys(instance.bBoxArgs).map((name, i) => {
+        const arg = instance.bBoxArgs[name];
+
+        return (
+          <rect
+            key={i}
+            x={arg.coords.x}
+            y={arg.coords.y}
+            height={arg.extent.height}
+            width={arg.extent.width}
+            fill="green"
+            opacity={0.8}
+          />
+        );
+      })}
+
+      {/* Left notch bounding box */}
+      <rect
+        x={instance.bBoxNotchArg.coords.x}
+        y={instance.bBoxNotchArg.coords.y}
+        height={instance.bBoxNotchArg.extent.height}
+        width={instance.bBoxNotchArg.extent.width}
+        fill="green"
+        opacity={0.8}
+      />
+    </>
+  );
+
   return (
     <BrickWrapper>
-      <Component instance={instance} />
+      <Component instance={instance} visualIndicators={<VisualIndicators />} />
     </BrickWrapper>
   );
 }

--- a/modules/code-builder/src/brick/stories/components/BrickStatement.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickStatement.tsx
@@ -1,11 +1,11 @@
-import type { IBrickStatement, TBrickArgDataType, TBrickColor } from '@/@types/brick';
-
 import BrickWrapper from './BrickWrapper';
+import type { JSX } from 'react';
+import type { IBrickStatement, TBrickArgDataType, TBrickColor } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
 export default function (props: {
-  Component: (props: { instance: IBrickStatement }) => JSX.Element;
+  Component: (props: { instance: IBrickStatement; visualIndicators?: JSX.Element }) => JSX.Element;
   prototype: new (params: {
     name: string;
     label: string;
@@ -52,9 +52,60 @@ export default function (props: {
     name: '',
   });
 
+  const VisualIndicators = () => (
+    <>
+      {/* Overall Bounding Box of the Brick */}
+      {/* <rect
+        x={instance.bBoxBrick.coords.x}
+        y={instance.bBoxBrick.coords.y}
+        height={instance.bBoxBrick.extent.height}
+        width={instance.bBoxBrick.extent.width}
+        fill="green"
+        opacity={0.2}
+      /> */}
+
+      {/* Right args bounding box */}
+      {Object.keys(instance.bBoxArgs).map((name, i) => {
+        const arg = instance.bBoxArgs[name];
+
+        return (
+          <rect
+            key={i}
+            x={arg.coords.x}
+            y={arg.coords.y}
+            height={arg.extent.height}
+            width={arg.extent.width}
+            fill="green"
+            opacity={0.8}
+          />
+        );
+      })}
+
+      {/* Top instruction notch bounding box */}
+      <rect
+        x={instance.bBoxNotchInsTop.coords.x}
+        y={instance.bBoxNotchInsTop.coords.y}
+        height={instance.bBoxNotchInsTop.extent.height}
+        width={instance.bBoxNotchInsTop.extent.width}
+        fill="green"
+        opacity={0.9}
+      />
+
+      {/* Bottom instruction notch bounding box */}
+      <rect
+        x={instance.bBoxNotchInsBot.coords.x}
+        y={instance.bBoxNotchInsBot.coords.y}
+        height={instance.bBoxNotchInsBot.extent.height}
+        width={instance.bBoxNotchInsBot.extent.width}
+        fill="green"
+        opacity={0.9}
+      />
+    </>
+  );
+
   return (
     <BrickWrapper>
-      <Component instance={instance} />
+      <Component instance={instance} visualIndicators={<VisualIndicators />} />
     </BrickWrapper>
   );
 }

--- a/modules/code-builder/src/brick/stories/components/BrickStatement.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickStatement.tsx
@@ -105,7 +105,8 @@ export default function (props: {
 
   return (
     <BrickWrapper>
-      <Component instance={instance} visualIndicators={<VisualIndicators />} />
+      <Component instance={instance} />
+      <VisualIndicators />
     </BrickWrapper>
   );
 }

--- a/modules/code-builder/src/brick/stories/components/BrickStatement.tsx
+++ b/modules/code-builder/src/brick/stories/components/BrickStatement.tsx
@@ -55,14 +55,14 @@ export default function (props: {
   const VisualIndicators = () => (
     <>
       {/* Overall Bounding Box of the Brick */}
-      {/* <rect
+      <rect
         x={instance.bBoxBrick.coords.x}
         y={instance.bBoxBrick.coords.y}
         height={instance.bBoxBrick.extent.height}
         width={instance.bBoxBrick.extent.width}
-        fill="green"
-        opacity={0.2}
-      /> */}
+        fill="black"
+        opacity={0.25}
+      />
 
       {/* Right args bounding box */}
       {Object.keys(instance.bBoxArgs).map((name, i) => {


### PR DESCRIPTION
Implement and fix calculations to get the `extent` and `coords` values for the args and notches for all the bricks to detect the positions (x, y coordinates) and bounding boxes.

## Objectives

- [x] Return data for all bounding boxes
  - [x] `bBoxBrick`
  - [x] `bBoxNotchArg`
  - [x] `bBoxNotchInsTop`
  - [x] `bBoxNotchInsBot`
  - [x] `bBoxNotchInsNestTop`
  - [x] `bBoxArgs`
- [x] Change the types and classes of the bricks to expose args and notches' data using getter methods
- [x] Draw the bounding boxes (rectangles of different outline colours) for all of the args and notches over the bricks, to visually verify the calculations are correct (in the storybook)
- [x] Add missing tests inside `path.spec.ts` 


### Here are some of the Storybook screenshots:

<img src="https://github.com/sugarlabs/musicblocks-v4/assets/58071992/809363e0-2ea8-4a31-99a0-bcd107219524" width="400px" />
<img src="https://github.com/sugarlabs/musicblocks-v4/assets/58071992/69abc880-3c0f-4467-9eef-f43eaf85700c" width="400px" />
<img src="https://github.com/sugarlabs/musicblocks-v4/assets/58071992/8146fb0a-b369-4be8-b351-bfe33fd2b7c0" width="400px" />
<img src="https://github.com/sugarlabs/musicblocks-v4/assets/58071992/222315cf-a2fb-4a35-81a9-73c8cf754c8e" width="400px" />


Closes #341 