### PR TITLE
feat(playground): dummy workspace inside playground

### DIFF
--- a/modules/code-builder/playground/index.tsx
+++ b/modules/code-builder/playground/index.tsx
@@ -2,11 +2,16 @@ import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 
 import PageCollision from './pages/Collision';
+import WorkSpace from './pages/WorkSpace';
 
 const router = createBrowserRouter([
   {
     path: '/collision',
     element: <PageCollision />,
+  },
+  {
+    path: '/workspace',
+    element: <WorkSpace />,
   },
   {
     path: '/',

--- a/modules/code-builder/playground/pages/WorkSpace/data.ts
+++ b/modules/code-builder/playground/pages/WorkSpace/data.ts
@@ -1,0 +1,213 @@
+import {
+    ModelBrickBlock,
+    ModelBrickData,
+    ModelBrickExpression,
+    ModelBrickStatement,
+} from '@/brick';
+import type { TBrickType, TBrickCoords, TBrickArgDataType } from '@/@types/brick';
+
+type InstanceMap = {
+    data: ModelBrickData;
+    expression: ModelBrickExpression;
+    statement: ModelBrickStatement;
+    block: ModelBrickBlock;
+};
+
+export type Brick = {
+    id: string;
+    type: TBrickType;
+    instance: InstanceMap[TBrickType];
+    coords: TBrickCoords;
+    children?: Brick[];
+};
+
+export const WORKSPACES_DATA: { id: string; data: Brick[] }[] = [
+    {
+        id: 'workspace1',
+        data: [
+            {
+                id: '1',
+                type: 'block',
+                instance: new ModelBrickBlock({
+                    label: 'Block',
+                    args: Object.fromEntries(
+                        [].map<
+                            [string, { label: string; dataType: TBrickArgDataType; meta: unknown }]
+                        >((name) => [name, { label: name, dataType: 'any', meta: undefined }]),
+                    ),
+                    colorBg: 'yellow',
+                    colorFg: 'black',
+                    outline: 'red',
+                    scale: 2,
+                    glyph: '',
+                    connectAbove: true,
+                    connectBelow: true,
+                    name: '',
+                    nestLengthY: 125,
+                }),
+                coords: { x: 50, y: 50 },
+                children: [
+                    {
+                        id: '2',
+                        type: 'statement',
+                        instance: new ModelBrickStatement({
+                            label: 'Statement',
+                            args: Object.fromEntries(
+                                [].map<
+                                    [
+                                        string,
+                                        {
+                                            label: string;
+                                            dataType: TBrickArgDataType;
+                                            meta: unknown;
+                                        },
+                                    ]
+                                >((name) => [
+                                    name,
+                                    { label: name, dataType: 'any', meta: undefined },
+                                ]),
+                            ),
+                            colorBg: 'lightblue',
+                            colorFg: 'black',
+                            outline: 'blue',
+                            scale: 2,
+                            glyph: '',
+                            connectAbove: true,
+                            connectBelow: true,
+                            name: '',
+                        }),
+                        coords: { x: 68, y: 92 },
+                    },
+                    {
+                        id: '3',
+                        type: 'statement',
+                        instance: new ModelBrickStatement({
+                            label: 'Statement',
+                            args: Object.fromEntries(
+                                [].map<
+                                    [
+                                        string,
+                                        {
+                                            label: string;
+                                            dataType: TBrickArgDataType;
+                                            meta: unknown;
+                                        },
+                                    ]
+                                >((name) => [
+                                    name,
+                                    { label: name, dataType: 'any', meta: undefined },
+                                ]),
+                            ),
+                            colorBg: 'lightgreen',
+                            colorFg: 'black',
+                            outline: 'green',
+                            scale: 2,
+                            glyph: '',
+                            connectAbove: true,
+                            connectBelow: true,
+                            name: '',
+                        }),
+                        coords: { x: 68, y: 134 },
+                    },
+                    {
+                        id: '4',
+                        type: 'block',
+                        instance: new ModelBrickBlock({
+                            label: 'Block',
+                            args: Object.fromEntries(
+                                [].map<
+                                    [
+                                        string,
+                                        {
+                                            label: string;
+                                            dataType: TBrickArgDataType;
+                                            meta: unknown;
+                                        },
+                                    ]
+                                >((name) => [
+                                    name,
+                                    { label: name, dataType: 'any', meta: undefined },
+                                ]),
+                            ),
+                            colorBg: 'orange',
+                            colorFg: 'black',
+                            outline: 'grey',
+                            scale: 2,
+                            glyph: '',
+                            connectAbove: true,
+                            connectBelow: true,
+                            name: '',
+                            nestLengthY: 17,
+                        }),
+                        coords: { x: 68, y: 176 },
+                        children: [
+                            {
+                                id: '5',
+                                type: 'statement',
+                                instance: new ModelBrickStatement({
+                                    label: 'Statement',
+                                    args: Object.fromEntries(
+                                        [].map<
+                                            [
+                                                string,
+                                                {
+                                                    label: string;
+                                                    dataType: TBrickArgDataType;
+                                                    meta: unknown;
+                                                },
+                                            ]
+                                        >((name) => [
+                                            name,
+                                            { label: name, dataType: 'any', meta: undefined },
+                                        ]),
+                                    ),
+                                    colorBg: 'lightpink',
+                                    colorFg: 'black',
+                                    outline: 'deeppink',
+
+                                    scale: 2,
+                                    glyph: '',
+                                    connectAbove: true,
+                                    connectBelow: true,
+                                    name: '',
+                                }),
+                                coords: { x: 86, y: 218 },
+                            },
+                        ],
+                    },
+                    {
+                        id: '6',
+                        type: 'statement',
+                        instance: new ModelBrickStatement({
+                            label: 'Statement',
+                            args: Object.fromEntries(
+                                [].map<
+                                    [
+                                        string,
+                                        {
+                                            label: string;
+                                            dataType: TBrickArgDataType;
+                                            meta: unknown;
+                                        },
+                                    ]
+                                >((name) => [
+                                    name,
+                                    { label: name, dataType: 'any', meta: undefined },
+                                ]),
+                            ),
+                            colorBg: 'lightgreen',
+                            colorFg: 'black',
+                            outline: 'green',
+                            scale: 2,
+                            glyph: '',
+                            connectAbove: true,
+                            connectBelow: true,
+                            name: '',
+                        }),
+                        coords: { x: 68, y: 302 },
+                    },
+                ],
+            },
+        ],
+    },
+];

--- a/modules/code-builder/playground/pages/WorkSpace/index.tsx
+++ b/modules/code-builder/playground/pages/WorkSpace/index.tsx
@@ -1,0 +1,65 @@
+import {
+  BrickBlock,
+  BrickData,
+  BrickExpression,
+  BrickStatement,
+  ModelBrickBlock,
+  ModelBrickData,
+  ModelBrickExpression,
+  ModelBrickStatement,
+} from '@/brick';
+import { WORKSPACES_DATA } from './data';
+import type { TBrickCoords, TBrickType } from '@/@types/brick';
+import type { Brick } from './data';
+
+function getBrick(
+  type: TBrickType,
+  instance: ModelBrickBlock | ModelBrickData | ModelBrickExpression | ModelBrickStatement,
+  coords: TBrickCoords,
+) {
+  switch (type) {
+    case 'data':
+      return <BrickData instance={instance as ModelBrickData} coords={coords} />;
+    case 'expression':
+      return <BrickExpression instance={instance as ModelBrickExpression} coords={coords} />;
+    case 'statement':
+      return <BrickStatement instance={instance as ModelBrickStatement} coords={coords} />;
+    case 'block':
+      return <BrickBlock instance={instance as ModelBrickBlock} coords={coords} />;
+    default:
+      return <></>;
+  }
+}
+
+function RenderBricks({ brickData }: { brickData: Brick }) {
+  return (
+    <>
+      {getBrick(brickData.type, brickData.instance, brickData.coords)}
+      {brickData.children &&
+        brickData.children?.length > 0 &&
+        brickData.children.map((child) => <RenderBricks key={child.id} brickData={child} />)}
+    </>
+  );
+}
+
+function WorkSpace() {
+  return (
+    <div>
+      {WORKSPACES_DATA.map((workspace) => (
+        <svg
+          version="1.1"
+          xmlns="http://www.w3.org/2000/svg"
+          key={workspace.id}
+          height="500px"
+          width="500px"
+        >
+          {workspace.data.map((brick) => {
+            return <RenderBricks key={brick.id} brickData={brick} />;
+          })}
+        </svg>
+      ))}
+    </div>
+  );
+}
+
+export default WorkSpace;

--- a/modules/code-builder/src/brick/design0/BrickBlock.ts
+++ b/modules/code-builder/src/brick/design0/BrickBlock.ts
@@ -32,6 +32,7 @@ export default class BrickBlock extends BrickModelBlock {
         scale: number;
         connectAbove: boolean;
         connectBelow: boolean;
+        nestLengthY?: number;
     }) {
         super(params);
         const argsKeys = Object.keys(this._args);
@@ -41,7 +42,7 @@ export default class BrickBlock extends BrickModelBlock {
             hasNotchInsTop: this._connectAbove,
             hasNotchInsBot: this._connectBelow,
             scale: this._scale,
-            nestLengthY: 30,
+            nestLengthY: params.nestLengthY ?? 17,
             innerLengthX: 100,
             argHeights: Array.from({ length: argsKeys.length }, () => 17),
         });

--- a/modules/code-builder/src/brick/design0/components/BrickBlock.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickBlock.tsx
@@ -1,13 +1,17 @@
 import type { JSX } from 'react';
-import type { IBrickBlock } from '@/@types/brick';
+import type { IBrickBlock, TBrickCoords } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
-export default function (props: { instance: IBrickBlock }): JSX.Element {
-  const { instance } = props;
-
+export default function ({
+  instance,
+  coords = { x: 0, y: 0 },
+}: {
+  instance: IBrickBlock;
+  coords?: TBrickCoords;
+}): JSX.Element {
   return (
-    <g transform={`scale(${instance.scale})`}>
+    <g transform={`translate(${coords?.x},${coords?.y}) scale(${instance.scale})`}>
       <path
         d={instance.SVGpath}
         style={{

--- a/modules/code-builder/src/brick/design0/components/BrickData.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickData.tsx
@@ -1,11 +1,15 @@
 import type { JSX } from 'react';
-import type { IBrickData } from '@/@types/brick';
+import type { IBrickData, TBrickCoords } from '@/@types/brick';
 
-export default function (props: { instance: IBrickData }): JSX.Element {
-  const { instance } = props;
-
+export default function ({
+  instance,
+  coords = { x: 0, y: 0 },
+}: {
+  instance: IBrickData;
+  coords?: TBrickCoords;
+}): JSX.Element {
   return (
-    <g transform={`scale(${instance.scale})`}>
+    <g transform={`translate(${coords?.x},${coords?.y}) scale(${instance.scale})`}>
       <path
         d={instance.SVGpath}
         style={{

--- a/modules/code-builder/src/brick/design0/components/BrickExpression.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickExpression.tsx
@@ -1,13 +1,17 @@
 import type { JSX } from 'react';
-import type { IBrickExpression } from '@/@types/brick';
+import type { IBrickExpression, TBrickCoords } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
-export default function (props: { instance: IBrickExpression }): JSX.Element {
-  const { instance } = props;
-
+export default function ({
+  instance,
+  coords = { x: 0, y: 0 },
+}: {
+  instance: IBrickExpression;
+  coords?: TBrickCoords;
+}): JSX.Element {
   return (
-    <g transform={`scale(${instance.scale})`}>
+    <g transform={`translate(${coords?.x},${coords?.y}) scale(${instance.scale})`}>
       <path
         d={instance.SVGpath}
         style={{

--- a/modules/code-builder/src/brick/design0/components/BrickStatement.tsx
+++ b/modules/code-builder/src/brick/design0/components/BrickStatement.tsx
@@ -1,13 +1,17 @@
 import type { JSX } from 'react';
-import type { IBrickStatement } from '@/@types/brick';
+import type { IBrickStatement, TBrickCoords } from '@/@types/brick';
 
 // -------------------------------------------------------------------------------------------------
 
-export default function (props: { instance: IBrickStatement }): JSX.Element {
-  const { instance } = props;
-
+export default function ({
+  instance,
+  coords = { x: 0, y: 0 },
+}: {
+  instance: IBrickStatement;
+  coords?: TBrickCoords;
+}): JSX.Element {
   return (
-    <g transform={`scale(${instance.scale})`}>
+    <g transform={`translate(${coords?.x},${coords?.y}) scale(${instance.scale})`}>
       <path
         d={instance.SVGpath}
         style={{


### PR DESCRIPTION
### This Pull Request Covers:

I've created a dummy workspace using the previously created bricks, custom recursive components and the tree state.

The dummy workspace state can be found here: [`modules/code-builder/playground/pages/WorkSpace/data.ts`](https://github.com/sugarlabs/musicblocks-v4/pull/361/files#diff-e71c31ef248cfcc0233649e45d2a26476768c87177d173460967496ee79e2097)

- [x] Modified the brick components to accept the `coords` to properly position them inside the SVG
- [x] Added `/workspace` route inside the `modules/code-builder/playground` app to render the dummy workspace

### Here's one screenshot:
<img src="https://github.com/sugarlabs/musicblocks-v4/assets/58071992/2756a1bf-7115-4f81-a87c-82aca7649a1c" height="400px"  />



closes #360 