### PR TITLE
fix: add globPatterns to PWA config to cache SVG and PNG assets for offline use

### DIFF
--- a/app/tools/vite.config.ts
+++ b/app/tools/vite.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
             workbox: {
                 clientsClaim: true,
                 skipWaiting: true,
+                globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
             },
         }),
         compression({


### PR DESCRIPTION
## Description
Fixes PWA offline caching for SVG and PNG assets by adding globPatterns to the Vite PWA workbox configuration.

## Changes
- Added `globPatterns: ['**/*.{js,css,html,ico,png,svg}']` to workbox configuration in `app/tools/vite.config.ts`

## Problem
Asset files generated during build with hashed filenames (e.g., `run-123f2282.svg`, `logo-3080f493.png`) were not being cached by the service worker, causing them to fail loading in offline mode.



## Solution
The globPatterns configuration ensures the service worker precaches all files matching the specified patterns, including SVG and PNG files regardless of their hash values.

## Testing
- ✅ Verified in DevTools Cache Storage that SVG and PNG files are now cached
- ✅ Confirmed offline functionality works with images loading correctly

Closes #321
